### PR TITLE
Creating security group rules in cap

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,3 @@
-output "security_group_rules" {
-  value = [
-    {
-      id       = local.db_security_group_id
-      protocol = "tcp"
-      port     = local.db_port
-    }
-  ]
-}
-
 output "env" {
   value = [
     {

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,17 @@
+resource "aws_security_group_rule" "app-to-datastore" {
+  security_group_id        = local.db_security_group_id
+  type                     = "egress"
+  from_port                = local.db_port
+  to_port                  = local.db_port
+  protocol                 = "tcp"
+  source_security_group_id = var.app_metadata["security_group_id"]
+}
+
+resource "aws_security_group_rule" "datastore-from-app" {
+  security_group_id        = var.app_metadata["security_group_id"]
+  type                     = "ingress"
+  from_port                = local.db_port
+  to_port                  = local.db_port
+  protocol                 = "tcp"
+  source_security_group_id = local.db_security_group_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "app_metadata" {
+  description = <<EOF
+App Metadata is injected from the app on-the-fly.
+This contains information about resources created in the app module that are needed by the capability.
+EOF
+
+  type    = map(string)
+  default = {}
+}
+
 variable "database_name" {
   type        = string
   description = "Name of database to create in Postgres cluster"


### PR DESCRIPTION
This moves security group rule creation into the capability as a result of dealing with issues doing dynamic count in terraform.