### PR TITLE
Directly emitting secret values for service to build

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,12 +14,12 @@ output "env" {
 output "secrets" {
   value = [
     {
-      name      = "POSTGRES_PASSWORD"
-      valueFrom = aws_secretsmanager_secret.password.arn
+      name  = "POSTGRES_PASSWORD"
+      value = random_password.this.result
     },
     {
-      name      = "POSTGRES_URL"
-      valueFrom = aws_secretsmanager_secret.url.arn
+      name  = "POSTGRES_URL"
+      value = "postgres://${urlencode(local.username)}:${urlencode(random_password.this.result)}@${local.db_endpoint}/${urlencode(local.database_name)}"
     }
   ]
 }

--- a/password.tf
+++ b/password.tf
@@ -6,13 +6,3 @@ resource "random_password" "this" {
   // The password for the master database user can include any printable ASCII character except /, ", @, or a space.
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
-
-resource "aws_secretsmanager_secret" "password" {
-  name = "${local.resource_name}/password"
-  tags = data.ns_workspace.this.tags
-}
-
-resource "aws_secretsmanager_secret_version" "password" {
-  secret_id     = aws_secretsmanager_secret.password.id
-  secret_string = random_password.this.result
-}

--- a/url.tf
+++ b/url.tf
@@ -1,9 +1,0 @@
-resource "aws_secretsmanager_secret" "url" {
-  name = "${local.resource_name}/url"
-  tags = data.ns_workspace.this.tags
-}
-
-resource "aws_secretsmanager_secret_version" "url" {
-  secret_id     = aws_secretsmanager_secret.url.id
-  secret_string = "postgres://${urlencode(local.username)}:${urlencode(random_password.this.result)}@${local.db_endpoint}/${urlencode(local.database_name)}"
-}


### PR DESCRIPTION
This PR modifies the module to adhere to the new service contract defined in https://github.com/nullstone-modules/aws-fargate-service/pull/18.

This module now has no awareness of a secrets manager.