### PR TITLE
B/1325 change db name

### DIFF
--- a/create.tf
+++ b/create.tf
@@ -15,6 +15,7 @@ resource "restapi_object" "database_owner" {
 
   path         = "/roles"
   id_attribute = "name"
+  object_id    = local.database_name
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -28,6 +29,7 @@ resource "restapi_object" "database" {
 
   path         = "/databases"
   id_attribute = "name"
+  object_id    = local.database_name
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -44,6 +46,7 @@ resource "restapi_object" "role" {
 
   path         = "/roles"
   id_attribute = "name"
+  object_id    = local.username
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -58,6 +61,7 @@ resource "restapi_object" "role_member" {
 
   path         = "/roles/${local.database_owner}/members"
   id_attribute = "member"
+  object_id    = "${local.database_owner}::${local.username}"
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -77,11 +81,12 @@ resource "restapi_object" "schema_privileges" {
 
   path         = "/databases/${local.database_name}/schema_privileges"
   id_attribute = "role"
+  object_id    = "${local.database_name}::${local.username}"
   destroy_path = "/skip"
 
   data = jsonencode({
-    database    = local.database_name
-    role        = local.username
+    database = local.database_name
+    role     = local.username
   })
 
   depends_on = [
@@ -95,12 +100,13 @@ resource "restapi_object" "default_grants" {
 
   path         = "/roles/${local.username}/default_grants"
   id_attribute = "id"
+  object_id    = "${local.username}::${local.database_owner}::${local.database_name}"
   destroy_path = "/skip"
 
   data = jsonencode({
-    role        = local.username
-    target      = local.database_owner
-    database    = local.database_name
+    role     = local.username
+    target   = local.database_owner
+    database = local.database_name
   })
 
   depends_on = [

--- a/create.tf
+++ b/create.tf
@@ -1,5 +1,5 @@
 provider "restapi" {
-  uri                  = coalesce(local.db_admin_func_url, "https://noop")
+  uri                  = coalesce(local.db_admin_func_url, "https://missing-db-admin-url")
   write_returns_object = true
   rate_limit           = 2 // Allow 2 requests per second
 

--- a/create.tf
+++ b/create.tf
@@ -16,6 +16,7 @@ resource "restapi_object" "database_owner" {
   path         = "/roles"
   id_attribute = "name"
   object_id    = local.database_name
+  force_new    = [local.database_name]
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -30,6 +31,7 @@ resource "restapi_object" "database" {
   path         = "/databases"
   id_attribute = "name"
   object_id    = local.database_name
+  force_new    = [local.database_name]
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -47,6 +49,7 @@ resource "restapi_object" "role" {
   path         = "/roles"
   id_attribute = "name"
   object_id    = local.username
+  force_new    = [local.username]
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -62,6 +65,7 @@ resource "restapi_object" "role_member" {
   path         = "/roles/${local.database_owner}/members"
   id_attribute = "member"
   object_id    = "${local.database_owner}::${local.username}"
+  force_new    = [local.database_owner, local.username]
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -82,6 +86,7 @@ resource "restapi_object" "schema_privileges" {
   path         = "/databases/${local.database_name}/schema_privileges"
   id_attribute = "role"
   object_id    = "${local.database_name}::${local.username}"
+  force_new    = [local.database_name, local.username]
   destroy_path = "/skip"
 
   data = jsonencode({
@@ -101,6 +106,7 @@ resource "restapi_object" "default_grants" {
   path         = "/roles/${local.username}/default_grants"
   id_attribute = "id"
   object_id    = "${local.username}::${local.database_owner}::${local.database_name}"
+  force_new    = [local.username, local.database_owner, local.database_name]
   destroy_path = "/skip"
 
   data = jsonencode({

--- a/create_legacy.tf
+++ b/create_legacy.tf
@@ -1,7 +1,7 @@
 // Create Database will create a database
 // Additionally, a role of the same name will be created and given "owner" over database
 data "aws_lambda_invocation" "create-database" {
-  count         = local.db_admin_v5 ? 0 : 1
+  count = local.db_admin_v5 ? 0 : 1
 
   function_name = local.db_admin_func_name
 
@@ -14,7 +14,7 @@ data "aws_lambda_invocation" "create-database" {
 }
 
 data "aws_lambda_invocation" "create-user" {
-  count         = local.db_admin_v5 ? 0 : 1
+  count = local.db_admin_v5 ? 0 : 1
 
   function_name = local.db_admin_func_name
 
@@ -30,7 +30,7 @@ data "aws_lambda_invocation" "create-user" {
 }
 
 data "aws_lambda_invocation" "create-db-access" {
-  count         = local.db_admin_v5 ? 0 : 1
+  count = local.db_admin_v5 ? 0 : 1
 
   function_name = local.db_admin_func_name
 

--- a/postgres.tf
+++ b/postgres.tf
@@ -10,7 +10,7 @@ locals {
   db_security_group_id = data.ns_connection.postgres.outputs.db_security_group_id
 }
 
- locals {
+locals {
   db_admin_func_name = data.ns_connection.postgres.outputs.db_admin_function_name
   db_admin_invoker   = try(data.ns_connection.postgres.outputs.db_admin_invoker, null)
   db_admin_v5        = local.db_admin_invoker != null


### PR DESCRIPTION
This fixes an issue where postgres access would not work if launched, then `database_name` variable was changed.
The `restapi_object` Terraform resources were incorrectly updating instead of recreating.
The included changes use `force_new` to "taint" each `restapi_object` if any uniquely-identifying value changes.

This change was verified locally.