### PR TITLE
Add support for interpolating database_name with workspace names

### DIFF
--- a/nullstone.tf
+++ b/nullstone.tf
@@ -22,6 +22,8 @@ resource "random_string" "resource_suffix" {
 
 locals {
   tags          = data.ns_workspace.this.tags
+  stack_name    = data.ns_workspace.this.stack_name
   block_name    = data.ns_workspace.this.block_name
+  env_name      = data.ns_workspace.this.env_name
   resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,15 +8,35 @@ EOF
   default = {}
 }
 
+locals {
+  security_group_id = var.app_metadata["security_group_id"]
+}
+
 variable "database_name" {
   type        = string
-  description = "Name of database to create in Postgres cluster. If left blank, uses app name."
+  description = <<EOF
+Name of database to create in Postgres cluster. If left blank, uses app name.
+The following identifiers are supported for interpolation:
+  {{ NULLSTONE_STACK }}
+  {{ NULLSTONE_BLOCK }}
+  {{ NULLSTONE_ENV }}
+EOF
   default     = ""
 }
 
+// We are using ns_env_variables to interpolate database_name
+data "ns_env_variables" "db_name" {
+  input_env_variables = tomap({
+    NULLSTONE_STACK = local.stack_name
+    NULLSTONE_APP   = local.block_name
+    NULLSTONE_ENV   = local.env_name
+    DATABASE_NAME   = coalesce(var.database_name, local.block_name)
+  })
+  input_secrets = tomap({})
+}
+
 locals {
-  security_group_id = var.app_metadata["security_group_id"]
-  username          = local.resource_name
-  database_name     = coalesce(var.database_name, local.block_name)
-  database_owner    = local.database_name
+  username       = local.resource_name
+  database_name  = data.ns_env_variables.db_name.env_variables["DATABASE_NAME"]
+  database_owner = local.database_name
 }


### PR DESCRIPTION
This adds support for interpolating `NULLSTONE_STACK`, `NULLSTONE_BLOCK`, and `NULLSTONE_ENV` in a database name.

This allows a user to specify an env-specific database in a preview environment.